### PR TITLE
Return {nil, nil} when not found in find_both for easier matching

### DIFF
--- a/lib/swiss/enum.ex
+++ b/lib/swiss/enum.ex
@@ -57,15 +57,15 @@ defmodule Swiss.Enum do
       {44, 1}
 
       iex> Swiss.Enum.find_both([42, 44, 46], fn num -> num == 45 end)
-      nil
+      {nil, nil}
   """
   def find_both(enumerable, fun) do
     enumerable
     |> Stream.with_index()
-    |> Enum.reduce_while(nil, fn {el, idx}, nil ->
+    |> Enum.reduce_while({nil, nil}, fn {el, idx}, {nil, nil} ->
       if fun.(el),
         do: {:halt, {el, idx}},
-        else: {:cont, nil}
+        else: {:cont, {nil, nil}}
     end)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Swiss.MixProject do
     [
       app: :swiss,
       description: "Swiss is a bundle of extensions to the standard lib.",
-      version: "2.8.1",
+      version: "2.8.2",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Can still use `cond` easily, but can also do `{el, idx} = Swiss.Enum.find_both/2` and postpone the nil check.