### PR TITLE
Defines `is_present/1` as a macro. Closes #36

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Elixir
       uses: actions/setup-elixir@v1
       with:
-        elixir-version: '1.9.4' # Define the elixir version [required]
+        elixir-version: '1.10.2' # Define the elixir version [required]
         otp-version: '22.3' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ by adding `swiss` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:swiss, "~> 2.14.0"}
+    {:swiss, "~> 3.0.0"}
   ]
 end
 ```

--- a/lib/swiss.ex
+++ b/lib/swiss.ex
@@ -12,6 +12,26 @@ defmodule Swiss do
   """
 
   @doc """
+  More idiomatic `!is_nil/1`. Defined as a macro so it can be used in guards.
+
+  ### Examples
+
+      iex> Swiss.is_present(nil)
+      false
+
+      iex> Swiss.is_present([])
+      true
+
+      iex> Swiss.is_present(42)
+      true
+  """
+  defmacro is_present(val) do
+    quote do
+      not is_nil(unquote(val))
+    end
+  end
+
+  @doc """
   Applies the given `func` to `value` and returns its result.
 
   ### Examples
@@ -85,24 +105,6 @@ defmodule Swiss do
       do: val,
       else: apply_fn.(val)
   end
-
-  @doc """
-  More idiomatic `!is_nil/1`.
-
-  ### Examples
-
-      iex> Swiss.is_present(nil)
-      false
-
-      iex> Swiss.is_present([])
-      true
-
-      iex> Swiss.is_present(42)
-      true
-  """
-  @spec is_present(val :: any()) :: boolean()
-  def is_present(val),
-    do: !is_nil(val)
 
   @doc """
   Wrapper that makes any function usable directly in `Kernel.get_in/2`.

--- a/mix.exs
+++ b/mix.exs
@@ -5,8 +5,8 @@ defmodule Swiss.MixProject do
     [
       app: :swiss,
       description: "Swiss is a bundle of extensions to the standard lib.",
-      elixir: "~> 1.9",
-      version: "2.14.0",
+      elixir: "~> 1.10",
+      version: "3.0.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Bumped minimum elixir version, dependencies on own macros don't seem to work on 1.9.