### PR TITLE
Hotfix: removes dependency in ecto struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add `swiss` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:swiss, "~> 3.4.0"}
+    {:swiss, "~> 3.4.3"}
   ]
 end
 ```

--- a/lib/swiss/ecto.ex
+++ b/lib/swiss/ecto.ex
@@ -25,8 +25,7 @@ defmodule Swiss.Ecto do
   @spec assoc_present?(assoc :: term(), accept_nil? :: boolean) :: boolean()
   def assoc_present?(assoc, accept_nil? \\ false)
   def assoc_present?(nil, accept_nil?), do: accept_nil?
-  def assoc_present?(%Ecto.Association.NotLoaded{}, _), do: false
-  def assoc_present?(%_{}, _), do: true
+  def assoc_present?(%module{}, _), do: module !== Ecto.Association.NotLoaded
   def assoc_present?(assoc, _) when is_list(assoc), do: true
   def assoc_present?(assoc, _), do: raise("unexpected assoc type: #{inspect(assoc)}")
 end

--- a/lib/swiss/ecto/schema.ex
+++ b/lib/swiss/ecto/schema.ex
@@ -9,7 +9,7 @@ defmodule Swiss.Ecto.Schema do
     schema
     |> Map.from_struct()
     |> Enum.filter(fn
-      {_, %Ecto.Association.NotLoaded{}} -> false
+      {_, %module{}} when module == Ecto.Association.NotLoaded -> false
       {_, nil} -> false
       _ -> true
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Swiss.MixProject do
       app: :swiss,
       description: "Swiss is a bundle of extensions to the standard lib.",
       elixir: "~> 1.10",
-      version: "3.4.2",
+      version: "3.4.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Can't compile without Ecto dependency due to compile-time struct field verification.